### PR TITLE
Stream logs from docker

### DIFF
--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -429,7 +429,7 @@ class Plugin(WIPPPluginManifest):
                 args.append(str(o.value))
 
         client = docker.from_env()
-        client.containers.run(
+        dc = client.containers.run(
             self.containerId,
             args,
             mounts=mnts,
@@ -437,7 +437,12 @@ class Plugin(WIPPPluginManifest):
             device_requests=[
                 docker.types.DeviceRequest(count=-1, capabilities=[["gpu"]])
             ],
+            remove=True,  # remove container after stopping
+            detach=True,  # equivalent to -d in CLI
         )
+
+        for l in dc.logs(stream=True, follow=True):
+            print(l.decode("utf-8").strip())
 
     def __getattribute__(self, name):
         if name != "_io_keys" and hasattr(self, "_io_keys"):


### PR DESCRIPTION
With these changes the docker container will run in detached mode and the logs from the python script running inside the container will be streamed and printed into the standard output of the script running `polus-plugins`.

Additionally, the container will now be removed after stopping.