### PR TITLE
Mount multiple I/O directories

### DIFF
--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -396,7 +396,7 @@ class Plugin(WIPPPluginManifest):
             if isinstance(o.value, pathlib.Path):
                 out_dirs.append(str(o.value))
 
-        inp_dirs_dict = {x: f"/data/iputs/input{n}" for (n, x) in enumerate(inp_dirs)}
+        inp_dirs_dict = {x: f"/data/inputs/input{n}" for (n, x) in enumerate(inp_dirs)}
         out_dirs_dict = {
             x: f"/data/outputs/output{n}" for (n, x) in enumerate(out_dirs)
         }

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -429,7 +429,7 @@ class Plugin(WIPPPluginManifest):
                 args.append(str(o.value))
 
         client = docker.from_env()
-        client.containers.run(
+        dc = client.containers.run(
             self.containerId,
             args,
             mounts=mnts,
@@ -437,7 +437,12 @@ class Plugin(WIPPPluginManifest):
             device_requests=[
                 docker.types.DeviceRequest(count=-1, capabilities=[["gpu"]])
             ],
+            remove=True,  # remove container after stopping
+            detach=True,  # equivalent to -d in CLI
         )
+
+        for l in dc.logs(stream=True, follow=True):
+            print(l.decode("utf-8").strip())
 
     def __getattribute__(self, name):
         if name != "_io_keys" and hasattr(self, "_io_keys"):


### PR DESCRIPTION
*To be merged after https://github.com/PolusAI/polus-plugins/pull/245*

These changes introduce better volume management for docker containers run with `Plugin.run()`. Each I/O directory is now mounted individually instead of mounting a common path.