### PR TITLE
Implement `python-on-whales` docker API

### DIFF
--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -429,7 +429,7 @@ class Plugin(WIPPPluginManifest):
                 args.append(str(o.value))
 
         client = docker.from_env()
-        client.containers.run(
+        dc = client.containers.run(
             self.containerId,
             args,
             mounts=mnts,
@@ -437,7 +437,12 @@ class Plugin(WIPPPluginManifest):
             device_requests=[
                 docker.types.DeviceRequest(count=-1, capabilities=[["gpu"]])
             ],
+            remove=True,  # remove container after stopping
+            detach=True,  # equivalent to -d in CLI
         )
+
+        for l in dc.logs(stream=True, follow=True):
+            print(l.decode("utf-8").strip())
 
     def __getattribute__(self, name):
         if name != "_io_keys" and hasattr(self, "_io_keys"):

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -338,11 +338,11 @@ class Input(WippInput, IOBase):
             )
 
 
-class RunSettings(object):
+# class RunSettings(object):
 
-    gpu: typing.Union[int, typing.List[int], None] = -1
-    gpu: typing.Union[int, None] = -1
-    mem: int = -1
+#     gpu: typing.Union[int, typing.List[int], None] = -1
+#     gpu: typing.Union[int, None] = -1
+#     mem: int = -1
 
 
 class Plugin(WIPPPluginManifest):
@@ -383,7 +383,7 @@ class Plugin(WIPPPluginManifest):
     def organization(self):
         return self.containerId.split("/")[0]
 
-    def run(self):
+    def run(self, gpu: bool = True, gpu_count: int = -1, **kwargs):
 
         inp_dirs = []
         out_dirs = []
@@ -432,17 +432,31 @@ class Plugin(WIPPPluginManifest):
                 args.append(str(o.value))
 
         client = docker.from_env()
-        dc = client.containers.run(
-            self.containerId,
-            args,
-            mounts=mnts,
-            user=f"{os.getuid()}:{os.getegid()}",
-            device_requests=[
-                docker.types.DeviceRequest(count=-1, capabilities=[["gpu"]])
-            ],
-            remove=True,  # remove container after stopping
-            detach=True,  # equivalent to -d in CLI
-        )
+        if gpu:
+            logger.info("Running container with GPU. gpu_count = %s" % gpu_count)
+            dc = client.containers.run(
+                self.containerId,
+                args,
+                mounts=mnts,
+                user=f"{os.getuid()}:{os.getegid()}",
+                device_requests=[
+                    docker.types.DeviceRequest(count=gpu_count, capabilities=[["gpu"]])
+                ],
+                remove=True,  # remove container after stopping
+                detach=True,  # equivalent to -d in CLI,
+                **kwargs,
+            )
+        else:
+            logger.info("Running container without GPU")
+            dc = client.containers.run(
+                self.containerId,
+                args,
+                mounts=mnts,
+                user=f"{os.getuid()}:{os.getegid()}",
+                remove=True,  # remove container after stopping
+                detach=True,  # equivalent to -d in CLI,
+                **kwargs,
+            )
 
         for l in dc.logs(stream=True, follow=True):
             print(l.decode("utf-8").strip())

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -388,7 +388,6 @@ class Plugin(WIPPPluginManifest):
         inp_dirs = []
         out_dirs = []
 
-        # Find common paths in input and output directories
         for i in self.inputs:
             if isinstance(i.value, pathlib.Path):
                 inp_dirs.append(str(i.value))
@@ -397,15 +396,20 @@ class Plugin(WIPPPluginManifest):
             if isinstance(o.value, pathlib.Path):
                 out_dirs.append(str(o.value))
 
-        inp_root = pathlib.Path(os.path.commonpath(inp_dirs))
-        out_root = pathlib.Path(os.path.commonpath(out_dirs))
-        mnts = [
-            docker.types.Mount(
-                "/data/inputs/", str(inp_root), type="bind", read_only=True
-            ),
-            docker.types.Mount("/data/outputs/", str(out_root), type="bind"),
+        inp_dirs_dict = {x: f"/data/inputs/input{n}" for (n, x) in enumerate(inp_dirs)}
+        out_dirs_dict = {
+            x: f"/data/outputs/output{n}" for (n, x) in enumerate(out_dirs)
+        }
+
+        mnts_in = [
+            docker.types.Mount(v, k, type="bind", read_only=True)
+            for (k, v) in inp_dirs_dict.items()
+        ]
+        mnts_out = [
+            docker.types.Mount(v, k, type="bind") for (k, v) in out_dirs_dict.items()
         ]
 
+        mnts = mnts_in + mnts_out
         args = []
 
         for i in self.inputs:
@@ -413,7 +417,7 @@ class Plugin(WIPPPluginManifest):
             args.append(f"--{i.name}")
 
             if isinstance(i.value, pathlib.Path):
-                args.append("/data/inputs" + str(i.value.relative_to(inp_root))[1:])
+                args.append(inp_dirs_dict[str(i.value)])
 
             else:
                 args.append(str(i.value))
@@ -423,8 +427,7 @@ class Plugin(WIPPPluginManifest):
             args.append(f"--{o.name}")
 
             if isinstance(o.value, pathlib.Path):
-                args.append("/data/outputs" + str(o.value.relative_to(out_root))[1:])
-
+                args.append(out_dirs_dict[str(o.value)])
             else:
                 args.append(str(o.value))
 

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -7,8 +7,11 @@ import re
 import pprint
 import os
 import uuid
+import signal
+import random
 
-import docker
+from typing import Union
+from python_on_whales import docker
 
 from pydantic import BaseModel, Extra, errors, validator
 from pydantic.error_wrappers import ValidationError
@@ -383,7 +386,11 @@ class Plugin(WIPPPluginManifest):
     def organization(self):
         return self.containerId.split("/")[0]
 
-    def run(self, gpu: bool = True, gpu_count: int = -1, **kwargs):
+    def run(
+        self,
+        gpus: Union[None, str, int] = "all",
+        **kwargs,
+    ):
 
         inp_dirs = []
         out_dirs = []
@@ -402,11 +409,12 @@ class Plugin(WIPPPluginManifest):
         }
 
         mnts_in = [
-            docker.types.Mount(v, k, type="bind", read_only=True)
+            [f"type=bind,source={k},target={v},readonly"]  # must be a list of lists
             for (k, v) in inp_dirs_dict.items()
         ]
         mnts_out = [
-            docker.types.Mount(v, k, type="bind") for (k, v) in out_dirs_dict.items()
+            [f"type=bind,source={k},target={v}"]  # must be a list of lists
+            for (k, v) in out_dirs_dict.items()
         ]
 
         mnts = mnts_in + mnts_out
@@ -431,35 +439,40 @@ class Plugin(WIPPPluginManifest):
             else:
                 args.append(str(o.value))
 
-        client = docker.from_env()
-        if gpu:
-            logger.info("Running container with GPU. gpu_count = %s" % gpu_count)
-            dc = client.containers.run(
-                self.containerId,
-                args,
-                mounts=mnts,
-                user=f"{os.getuid()}:{os.getegid()}",
-                device_requests=[
-                    docker.types.DeviceRequest(count=gpu_count, capabilities=[["gpu"]])
-                ],
-                remove=True,  # remove container after stopping
-                detach=True,  # equivalent to -d in CLI,
-                **kwargs,
-            )
-        else:
-            logger.info("Running container without GPU")
-            dc = client.containers.run(
-                self.containerId,
-                args,
-                mounts=mnts,
-                user=f"{os.getuid()}:{os.getegid()}",
-                remove=True,  # remove container after stopping
-                detach=True,  # equivalent to -d in CLI,
-                **kwargs,
-            )
+        container_name = f"polus{random.randint(10, 99)}"
 
-        for l in dc.logs(stream=True, follow=True):
-            print(l.decode("utf-8").strip())
+        def sig(
+            signal, frame
+        ):  # signal handler to kill container when KeyboardInterrupt
+            print(f"Exiting container {container_name}")
+            docker.kill(container_name)
+
+        signal.signal(
+            signal.SIGINT, sig
+        )  # make of sig the handler for KeyboardInterrupt
+        if gpus is None:
+            logger.info("Running container without GPU.")
+            d = docker.run(
+                self.containerId,
+                args,
+                name=container_name,
+                remove=True,
+                mounts=mnts,
+                **kwargs,
+            )
+            print(d)
+        else:
+            logger.info("Running container with GPU: --gpus %s" % gpus)
+            d = docker.run(
+                self.containerId,
+                args,
+                gpus=gpus,
+                name=container_name,
+                remove=True,
+                mounts=mnts,
+                **kwargs,
+            )
+            print(d)
 
     def __getattribute__(self, name):
         if name != "_io_keys" and hasattr(self, "_io_keys"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-
+python_on_whales>=0.34.0
 pygithub==1.55

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,10 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.7",
-    install_requires=["pygithub>=1.55", "docker>=5.0.3", "pydantic>=1.8.2"],
+    install_requires=[
+        "pygithub>=1.55",
+        "docker>=5.0.3",
+        "pydantic>=1.8.2",
+        "python_on_whales>=0.34.0",
+    ],
 )


### PR DESCRIPTION
*To be merged after #246*

This is a big change in the way that docker containers are run from `polus-plugins`. Instead of using [docker-py](https://github.com/docker/docker-py) which is complex to write and its documentation is very basic, this new mehtod uses [python-on-whales](https://github.com/gabrieldemarmiesse/python-on-whales).

### Docker containers are run with the following default settings:
* Containers are run with the `--rm` flag: they get removed after stopping
* All GPUs are exposed to the container by default (`--gpus all`).

### Managing GPUs
*Let `plugin` be an instance of the `Plugin` class*
By default, calling the method `run()` of  `plugin` will expose all GPUs to the docker container. An easy way to change this behavior is included:
* To prevent any GPU to be exposed to the docker container: run `plugin.run(gpus=None)`
* To expose the GPU with ID `abc-1234`: run `plugin.run(gpus="device=GPU-abc-1234")`
* To expose only 3 GPUs: run `plugin.run(gpus=3)`
* To expose only the first and fourth GPU: run `plugin.run(gpus="0,3")`

### Advantages:
* Written code in `plugins.py` is easier to read
* Output is streamed easily and *all* of the output is streamed. This means that now also the process of pulling docker images when local image does not exist is visible when running `plugin.run()`:
  ```
  22-Dec-21 17:27:46 - polus.plugins - INFO - Running container with GPU. --gpus all
  Unable to find image 'labshare/polus-intensity-projection-plugin:0.1.9' locally
  0.1.9: Pulling from labshare/polus-intensity-projection-plugin
  a076a628af6f: Pull complete 
  de8081929fad: Pull complete 
  181a96cb0617: Pull complete 
  c91fe2011cc2: Pull complete 
  8de944cde012: Pull complete 
  421c768f4642: Pull complete 
  fec4f8868341: Pull complete 
  68658bf6b72c: Pull complete 
  4286882cd739: Pull complete 
  5b048f6bd246: Pull complete 
  01697d9b0e02: Pull complete 
  Digest: sha256:12d6e79fdfde945d6e7d8e8458f98d4c035c4574844633bc9b8ad21b7160bcad
  Status: Downloaded newer image for labshare/polus-intensity-projection-plugin:0.1.9
  ```
* Passing arguments specific to `docker run` command is very easy:
 If for example you want to limit the number of cpus the container can use, if you were using docker-cli you would include the option `--cpus 4`. Now you can just include a keyword argument with the same name and the same value in `run()` like: `plugin.run(cpus=4)`. More information about keyword arguments [here](https://gabrieldemarmiesse.github.io/python-on-whales/sub-commands/container/#run)
* The ability to kill the container that is running was added: now generating a `SIGINT` signal with `KeyboardInterrupt` (<kbd>Ctrl</kbd> + <kbd>C</kbd>) kills the running docker container. To kill running docker container:  press <kbd>Ctrl</kbd> + <kbd>C</kbd>