### PR TITLE
Fix installation issues

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-graft polus/manifests

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("./polus/_plugins/VERSION", "r") as fh:
     with open("./polus/_plugins/VERSION", "w") as fw:
         fw.write(version)
 
-package_data = ["_plugins/VERSION"]
+package_data = ["_plugins/VERSION", "manifests/*"]
 
 setup(
     name="polus-plugins",


### PR DESCRIPTION
I made a mistake with `MANIFEST.in` and a directory `polus/manifests` was not being created at installation time.

I fixed this in `setup.py` and now `MANIFEST.in` is not needed.