### PR TITLE
Improved arg parsing

### DIFF
--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -492,7 +492,6 @@ class Plugin(WIPPPluginManifest):
             else:
                 args.append(str(o.value))
 
-
         container_name = f"polus{random.randint(10, 99)}"
 
         def sig(
@@ -552,6 +551,7 @@ class Plugin(WIPPPluginManifest):
                     % (name, self.__class__.__name__, value)
                 )
                 self._io_keys[name].value = value
+                return
             else:
                 raise IOKeyError(
                     "Attempting to set %s in %s but %s is not a valid I/O parameter"

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -34,6 +34,11 @@ logging.basicConfig(
 logger = logging.getLogger("polus.plugins")
 logger.setLevel(logging.INFO)
 
+
+class IOKeyError(Exception):
+    pass
+
+
 """
 Initialize the Github interface
 """
@@ -199,7 +204,7 @@ WIPP_TYPES = {
     "number": float,
     "string": str,
     "boolean": bool,
-    "array": list,
+    "array": str,
     "enum": enum.Enum,
 }
 
@@ -345,6 +350,7 @@ class IOBase(BaseModel):
                 )
                 raise
         else:
+
             value = WIPP_TYPES[self.type](value)
 
             if isinstance(value, pathlib.Path):
@@ -417,7 +423,7 @@ class Plugin(WIPPPluginManifest):
         self.Config.allow_mutation = True
         self._io_keys = {i.name: i for i in self.inputs}
         self._io_keys.update({o.name: o for o in self.outputs})
-        self.Config.allow_mutation = False
+        # self.Config.allow_mutation = False
 
         if self.author == "":
             logger.warning(
@@ -486,6 +492,7 @@ class Plugin(WIPPPluginManifest):
             else:
                 args.append(str(o.value))
 
+
         container_name = f"polus{random.randint(10, 99)}"
 
         def sig(
@@ -526,6 +533,8 @@ class Plugin(WIPPPluginManifest):
                 **kwargs,
             )
             print(d)
+
+    def __getattribute__(self, name):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
                 value = self._io_keys[name].value
@@ -538,8 +547,16 @@ class Plugin(WIPPPluginManifest):
     def __setattr__(self, name, value):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
+                logger.info(
+                    "Value of %s in %s set to %s"
+                    % (name, self.__class__.__name__, value)
+                )
                 self._io_keys[name].value = value
-                return
+            else:
+                raise IOKeyError(
+                    "Attempting to set %s in %s but %s is not a valid I/O parameter"
+                    % (name, self.__class__.__name__, name)
+                )
 
         super().__setattr__(name, value)
 

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -546,7 +546,7 @@ class Plugin(WIPPPluginManifest):
     def __setattr__(self, name, value):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
-                logger.info(
+                logger.debug(
                     "Value of %s in %s set to %s"
                     % (name, self.__class__.__name__, value)
                 )


### PR DESCRIPTION
*To be merged after #274*

These changes introduce:

* Arrays are now parsed as Python `str` letting docker handle it as an array: Without this, things like `plugin.layout = 'tp, xy'` would be converted to `['t', 'p', ',', ' ', 'x', 'y']` by Python. However, if `--layout 'tp, xy'` is passed to docker, it will run correctly.
* Manual handling of error messages when trying to set a value for a parameter not in the plugin's I/O parameters: When trying to set the value of a parameter that is not part of the I/O keys of the plugin, a clear message will be raised with `IOKeyError`
* Logger DEBUG shows when values are set and it shows how Python parsed them ( e.g  `Layout in BasicFlatfieldCorrectionPlugin set to 'tp,xy'`)

