### PR TITLE
feat: added methods to save manifest and I/O config to disk

### DIFF
--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -546,7 +546,7 @@ class Plugin(WIPPPluginManifest):
     def __setattr__(self, name, value):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
-                logger.info(
+                logger.debug(
                     "Value of %s in %s set to %s"
                     % (name, self.__class__.__name__, value)
                 )

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -762,12 +762,14 @@ def _error_log(val_err, manifest, fct):
             )
 
 
-def update_polus_plugins(gh_auth: typing.Optional[str] = None):
+def update_polus_plugins(
+    gh_auth: typing.Optional[str] = None, min_depth: int = 2, max_depth: int = 3
+):
 
     logger.info("Updating polus plugins.")
     # Get all manifests
     valid, invalid = scrape_manifests(
-        "polusai/polus-plugins", init_github(gh_auth), 1, 2, True
+        "polusai/polus-plugins", init_github(gh_auth), min_depth, max_depth, True
     )
     manifests = valid.copy()
     manifests.extend(invalid)

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -443,7 +443,7 @@ class Plugin(WIPPPluginManifest):
         return self.containerId.split("/")[0]
 
     @property
-    def config_file(self):
+    def _config_file(self):
         inp = {x.name: str(x.value) for x in self.inputs}
         out = {x.name: str(x.value) for x in self.outputs}
         config = {"inputs": inp, "outputs": out}
@@ -456,7 +456,7 @@ class Plugin(WIPPPluginManifest):
 
     def save_config(self, path: typing.Union[str, pathlib.Path]):
         with open(path, "w") as fw:
-            json.dump(self.config_file, fw)
+            json.dump(self._config_file, fw)
         logger.debug("Saved config to %s" % (path))
 
     def load_config(self, path: typing.Union[str, pathlib.Path]):
@@ -465,13 +465,17 @@ class Plugin(WIPPPluginManifest):
         inp = config["inputs"]
         out = config["outputs"]
         for k, v in inp.items():
-            setattr(self, k, v)
+            if k in self._io_keys:
+                setattr(self, k, v)
         for k, v in out.items():
-            setattr(self, k, v)
+            if k in self._io_keys:
+                setattr(self, k, v)
         logger.debug("Loaded config from %s" % (path))
 
     def run(
-        self, gpus: Union[None, str, int] = "all", **kwargs,
+        self,
+        gpus: Union[None, str, int] = "all",
+        **kwargs,
     ):
 
         inp_dirs = []
@@ -620,7 +624,8 @@ def is_valid_manifest(plugin: dict) -> bool:
 
 
 def submit_plugin(
-    manifest: typing.Union[str, dict, pathlib.Path], refresh: bool = False,
+    manifest: typing.Union[str, dict, pathlib.Path],
+    refresh: bool = False,
 ) -> Plugin:
     """Parses a plugin and returns a Plugin object.
 
@@ -907,7 +912,8 @@ class Registry:
         self.password = password
 
     def get_current_schema(
-        self, verify: bool = True,
+        self,
+        verify: bool = True,
     ):
         """Return current schema in WIPP"""
         response = requests.get(
@@ -923,7 +929,10 @@ class Registry:
             response.raise_for_status()
 
     def upload_data(
-        self, filepath, schema_id, verify: bool = True,
+        self,
+        filepath,
+        schema_id,
+        verify: bool = True,
     ):
         """Upload data to registry"""
         with open(filepath, "r") as file_reader:
@@ -953,7 +962,9 @@ class Registry:
         return response.json()
 
     def publish_data(
-        self, data, verify: bool = True,
+        self,
+        data,
+        verify: bool = True,
     ):
         """Publish to public workspace"""
         data_publish_id = data["id"] + "/publish/"
@@ -977,7 +988,10 @@ class Registry:
         return response.json()
 
     def patch_resource(
-        self, pid, version, verify: bool = True,
+        self,
+        pid,
+        version,
+        verify: bool = True,
     ):
         """Patch resource."""
         # Get current version of the resource


### PR DESCRIPTION
*To be merged after #295*

Let `Plugin` represent any instance of any Plugin.

New attributes:

* `Plugin.manifest`: Dictionary representation of the JSON Manifest of the Plugin.

New methods:
* `Plugin.save_manifest(path, indent (optional, default = 4)`: Save manifest as JSON file to the specified path. Optional indent argument defines how many spaces of indentation the file will have.
* `Plugin.save_config(path)`: Save a JSON file to the specified path, that contains input and output values that are currently set in the plugin instance.
* `Plugin.load_config(path)`: Loads a previously saved config JSON file and sets I/O values specified in it in for the current object.