### PR TITLE
feat: added methods to obtain all plugins from wipp registry

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-graft polus/manifests

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -526,6 +526,8 @@ class Plugin(WIPPPluginManifest):
                 **kwargs,
             )
             print(d)
+
+    def __getattribute__(self, name):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
                 value = self._io_keys[name].value

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -928,7 +928,9 @@ class registry:
         headers = {"Content-type": "application/json"}
         data = '{"query": {"$or":[{"Resource.role.type":"Plugin"},{"Resource.role.type.#text":"Plugin"}]}}'
         if self.username and self.password:
-            r = requests.post(url, headers=headers, data=data, auth=(self.username, self.password)) # authenticated request
+            r = requests.post(
+                url, headers=headers, data=data, auth=(self.username, self.password)
+            )  # authenticated request
         else:
             r = requests.post(url, headers=headers, data=data)
         valid, invalid = 0, {}

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -926,7 +926,7 @@ class registry:
     def update_plugins(self, verify: bool = True):
         url = self.registry_url + "/rest/data/query/"
         headers = {"Content-type": "application/json"}
-        data = '{"query":{}}'
+        data = '{"query": {"$or":[{"Resource.role.type":"Plugin"},{"Resource.role.type.#text":"Plugin"}]}}'
         if self.username and self.password:
             r = requests.post(url, headers=headers, data=data, auth=(self.username, self.password)) # authenticated request
         else:

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -927,7 +927,10 @@ class registry:
         url = self.registry_url + "/rest/data/query/"
         headers = {"Content-type": "application/json"}
         data = '{"query":{}}'
-        r = requests.post(url, headers=headers, data=data)
+        if self.username and self.password:
+            r = requests.post(url, headers=headers, data=data, auth=(self.username, self.password)) # authenticated request
+        else:
+            r = requests.post(url, headers=headers, data=data)
         valid, invalid = 0, {}
         for r in alive_it(r.json()["results"], title="Updating Plugins from WIPP"):
             try:

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -546,7 +546,7 @@ class Plugin(WIPPPluginManifest):
     def __setattr__(self, name, value):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
-                logger.info(
+                logger.debug(
                     "Value of %s in %s set to %s"
                     % (name, self.__class__.__name__, value)
                 )

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -762,12 +762,14 @@ def _error_log(val_err, manifest, fct):
             )
 
 
-def update_polus_plugins(gh_auth: typing.Optional[str] = None):
+def update_polus_plugins(
+    gh_auth: typing.Optional[str] = None, min_depth: int = 2, max_depth: int = 3
+):
 
     logger.info("Updating polus plugins.")
     # Get all manifests
     valid, invalid = scrape_manifests(
-        "polusai/polus-plugins", init_github(gh_auth), 1, 2, True
+        "polusai/polus-plugins", init_github(gh_auth), min_depth, max_depth, True
     )
     manifests = valid.copy()
     manifests.extend(invalid)

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -903,7 +903,7 @@ def update_nist_plugins(gh_auth: typing.Optional[str] = None):
             _error_log(val_err, manifest, "update_nist_plugins")
 
 
-class registry:
+class WippPluginRegistry:
     """Class that contains methods to interact with the REST API of WIPP Registry."""
 
     def __init__(
@@ -923,7 +923,7 @@ class registry:
         ]["#text"]
         return json.loads(d)
 
-    def update_plugins(self, verify: bool = True):
+    def update_plugins(self):
         url = self.registry_url + "/rest/data/query/"
         headers = {"Content-type": "application/json"}
         data = '{"query": {"$or":[{"Resource.role.type":"Plugin"},{"Resource.role.type.#text":"Plugin"}]}}'
@@ -936,58 +936,9 @@ class registry:
         valid, invalid = 0, {}
         for r in alive_it(r.json()["results"], title="Updating Plugins from WIPP"):
             try:
-                manifest = registry._parse_xml(r["xml_content"])
+                manifest = WippPluginRegistry._parse_xml(r["xml_content"])
                 plugin = submit_plugin(manifest)
-
-                """ Parsing checks specific to polus-plugins """
-                error_list = []
-
-                # Check that plugin version matches container version tag
-                container_name, version = tuple(plugin.containerId.split(":"))
-                version = Version(version=version)
-                organization, container_name = tuple(container_name.split("/"))
-                try:
-                    assert (
-                        plugin.version == version
-                    ), f"containerId version ({version}) does not match plugin version ({plugin.version})"
-                except AssertionError as err:
-                    error_list.append(err)
-
-                # Check to see that the plugin is registered to Labshare
-                try:
-                    assert organization in [
-                        "polusai",
-                        "labshare",
-                    ], "All polus plugin containers must be under the Labshare organization."
-                except AssertionError as err:
-                    error_list.append(err)
-
-                # Checks for container name, they are somewhat related to our
-                # Jenkins build
-                try:
-                    assert container_name.startswith(
-                        "polus"
-                    ), "containerId name must begin with polus-"
-                except AssertionError as err:
-                    error_list.append(err)
-
-                try:
-                    assert container_name.endswith(
-                        "plugin"
-                    ), "containerId name must end with -plugin"
-                except AssertionError as err:
-                    error_list.append(err)
-
-                if len(error_list) > 0:
-                    raise ValidationError(error_list, plugin.__class__)
                 valid += 1
-
-            except ValidationError as val_err:
-                _error_log(val_err, manifest, "registry.update_plugins")
-
-            except KeyError as key_err:
-                invalid.update({r["title"]: "Invalid format in WIPP"})
-
             except BaseException as err:
                 invalid.update({r["title"]: err.args[0]})
 
@@ -995,7 +946,7 @@ class registry:
                 if len(invalid) > 0:
                     self.invalid = invalid
                     logger.debug(
-                        "Submitted %s plugins successfully. See registry.invalid to check errors in unsubmitted plugins"
+                        "Submitted %s plugins successfully. See WippPluginRegistry.invalid to check errors in unsubmitted plugins"
                         % (valid)
                     )
                 logger.debug("Submitted %s plugins successfully." % (valid))

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -34,6 +34,11 @@ logging.basicConfig(
 logger = logging.getLogger("polus.plugins")
 logger.setLevel(logging.INFO)
 
+
+class IOKeyError(Exception):
+    pass
+
+
 """
 Initialize the Github interface
 """
@@ -199,7 +204,7 @@ WIPP_TYPES = {
     "number": float,
     "string": str,
     "boolean": bool,
-    "array": list,
+    "array": str,
     "enum": enum.Enum,
 }
 
@@ -345,6 +350,7 @@ class IOBase(BaseModel):
                 )
                 raise
         else:
+
             value = WIPP_TYPES[self.type](value)
 
             if isinstance(value, pathlib.Path):
@@ -417,7 +423,7 @@ class Plugin(WIPPPluginManifest):
         self.Config.allow_mutation = True
         self._io_keys = {i.name: i for i in self.inputs}
         self._io_keys.update({o.name: o for o in self.outputs})
-        self.Config.allow_mutation = False
+        # self.Config.allow_mutation = False
 
         if self.author == "":
             logger.warning(
@@ -540,8 +546,17 @@ class Plugin(WIPPPluginManifest):
     def __setattr__(self, name, value):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
+                logger.info(
+                    "Value of %s in %s set to %s"
+                    % (name, self.__class__.__name__, value)
+                )
                 self._io_keys[name].value = value
                 return
+            else:
+                raise IOKeyError(
+                    "Attempting to set %s in %s but %s is not a valid I/O parameter"
+                    % (name, self.__class__.__name__, name)
+                )
 
         super().__setattr__(name, value)
 

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -443,7 +443,7 @@ class Plugin(WIPPPluginManifest):
         return self.containerId.split("/")[0]
 
     @property
-    def config_file(self):
+    def _config_file(self):
         inp = {x.name: str(x.value) for x in self.inputs}
         out = {x.name: str(x.value) for x in self.outputs}
         config = {"inputs": inp, "outputs": out}
@@ -456,7 +456,7 @@ class Plugin(WIPPPluginManifest):
 
     def save_config(self, path: typing.Union[str, pathlib.Path]):
         with open(path, "w") as fw:
-            json.dump(self.config_file, fw)
+            json.dump(self._config_file, fw)
         logger.debug("Saved config to %s" % (path))
 
     def load_config(self, path: typing.Union[str, pathlib.Path]):
@@ -465,13 +465,17 @@ class Plugin(WIPPPluginManifest):
         inp = config["inputs"]
         out = config["outputs"]
         for k, v in inp.items():
-            setattr(self, k, v)
+            if k in self._io_keys:
+                setattr(self, k, v)
         for k, v in out.items():
-            setattr(self, k, v)
+            if k in self._io_keys:
+                setattr(self, k, v)
         logger.debug("Loaded config from %s" % (path))
 
     def run(
-        self, gpus: Union[None, str, int] = "all", **kwargs,
+        self,
+        gpus: Union[None, str, int] = "all",
+        **kwargs,
     ):
 
         inp_dirs = []
@@ -620,7 +624,8 @@ def is_valid_manifest(plugin: dict) -> bool:
 
 
 def submit_plugin(
-    manifest: typing.Union[str, dict, pathlib.Path], refresh: bool = False,
+    manifest: typing.Union[str, dict, pathlib.Path],
+    refresh: bool = False,
 ) -> Plugin:
     """Parses a plugin and returns a Plugin object.
 
@@ -907,7 +912,8 @@ class Registry:
         self.password = password
 
     def get_current_schema(
-        self, verify: bool = True,
+        self,
+        verify: bool = True,
     ):
         """Return current schema in WIPP"""
         response = requests.get(
@@ -923,7 +929,10 @@ class Registry:
             response.raise_for_status()
 
     def upload_data(
-        self, filepath, schema_id, verify: bool = True,
+        self,
+        filepath,
+        schema_id,
+        verify: bool = True,
     ):
         """Upload data to registry"""
         with open(filepath, "r") as file_reader:
@@ -953,7 +962,9 @@ class Registry:
         return response.json()
 
     def publish_data(
-        self, data, verify: bool = True,
+        self,
+        data,
+        verify: bool = True,
     ):
         """Publish to public workspace"""
         data_publish_id = data["id"] + "/publish/"
@@ -977,7 +988,10 @@ class Registry:
         return response.json()
 
     def patch_resource(
-        self, pid, version, verify: bool = True,
+        self,
+        pid,
+        version,
+        verify: bool = True,
     ):
         """Patch resource."""
         # Get current version of the resource

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python_on_whales>=0.34.0
 pygithub==1.55
 alive-progress>=2.1.0
+xmltodict>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("./polus/_plugins/VERSION", "r") as fh:
     with open("./polus/_plugins/VERSION", "w") as fw:
         fw.write(version)
 
-package_data = ["_plugins/VERSION"]
+package_data = ["_plugins/VERSION", "manifests/*"]
 
 setup(
     name="polus-plugins",

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
         "pydantic>=1.8.2",
         "python_on_whales>=0.34.0",
         "alive-progress>=2.1.0",
+        "xmltodict>=0.12.0",
     ],
 )


### PR DESCRIPTION
*To be merged after #311*

A new class: `plugins.registry()` is used to interact with WIPP Registry.
The method `registry.update_plugins()` will download plugins from WIPP Registry and submit them locally.
Example:
``` 
>>> from polus.plugins import plugins
>>> reg = plugins.registry() # can also be instantiated with username and password
>>> reg.update_plugins()
Updating Plugins from WIPP |████████████████████████████████████████| 2
>>> plugins.list()
['OmeZarrConverter', 'BasicFlatfieldCorrectionPlugin'] # example
```
Debugging:
* `DEBUG` messages are included. These contain information if there were plugins in WIPP that could not be submitted and the number of plugins successfully submitted.
*  `registry.invalid` is a dictionary that - **if there are plugins in WIPP that could not be submitted to `polus-plugins`** -gets populated with the names of the plugins and the respective error encountered.