### PR TITLE
refactor:  changed progressbar to reduce dependencies

### DIFF
--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -325,8 +325,8 @@ class IOBase(BaseModel):
             if isinstance(value, pathlib.Path):
 
                 value = value.absolute()
-                assert value.exists()
-                assert value.is_dir()
+                assert value.exists(), f"{value} is invalid or does not exist"
+                assert value.is_dir(), f"{value} is not a valid directory"
 
         super().__setattr__("value", value)
 
@@ -651,7 +651,7 @@ def scrape_manifests(
         max_depth = min_depth
         min_depth = 0
 
-    assert max_depth >= min_depth
+    assert max_depth >= min_depth, "max_depth is smaller than min_depth"
 
     if isinstance(repo, str):
         repo = gh.get_repo(repo)

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -928,7 +928,9 @@ class registry:
         headers = {"Content-type": "application/json"}
         data = '{"query": {"$or":[{"Resource.role.type":"Plugin"},{"Resource.role.type.#text":"Plugin"}]}}'
         if self.username and self.password:
-            r = requests.post(url, headers=headers, data=data, auth=(self.username, self.password)) # authenticated request
+            r = requests.post(
+                url, headers=headers, data=data, auth=(self.username, self.password)
+            )  # authenticated request
         else:
             r = requests.post(url, headers=headers, data=data)
         valid, invalid = 0, {}

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -926,7 +926,7 @@ class registry:
     def update_plugins(self, verify: bool = True):
         url = self.registry_url + "/rest/data/query/"
         headers = {"Content-type": "application/json"}
-        data = '{"query":{}}'
+        data = '{"query": {"$or":[{"Resource.role.type":"Plugin"},{"Resource.role.type.#text":"Plugin"}]}}'
         if self.username and self.password:
             r = requests.post(url, headers=headers, data=data, auth=(self.username, self.password)) # authenticated request
         else:

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -927,7 +927,10 @@ class registry:
         url = self.registry_url + "/rest/data/query/"
         headers = {"Content-type": "application/json"}
         data = '{"query":{}}'
-        r = requests.post(url, headers=headers, data=data)
+        if self.username and self.password:
+            r = requests.post(url, headers=headers, data=data, auth=(self.username, self.password)) # authenticated request
+        else:
+            r = requests.post(url, headers=headers, data=data)
         valid, invalid = 0, {}
         for r in alive_it(r.json()["results"], title="Updating Plugins from WIPP"):
             try:

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -77,10 +77,10 @@ class _Plugins(object):
         return object.__getattribute__(self, name)
 
     def __len__(self):
-        return len(self.list())
+        return len(self.list)
 
     def __repr__(self):
-        return pprint.pformat(self.list())
+        return pprint.pformat(self.list)
 
     @property
     def list(self):

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -13,7 +13,7 @@ import random
 import requests
 import xmltodict
 from urllib.parse import urlparse, urljoin
-from alive_progress import alive_it
+from tqdm import tqdm
 
 from typing import Union, Optional
 from python_on_whales import docker
@@ -743,7 +743,7 @@ def scrape_manifests(
 
     for d in range(0, max_depth):
 
-        for content in alive_it(contents, title=f"{repo.full_name}: {d}"):
+        for content in tqdm(contents, desc=f"{repo.full_name}: {d}"):
 
             if content.type == "dir":
                 next_contents.extend(repo.get_contents(content.path))
@@ -889,7 +889,7 @@ def update_nist_plugins(gh_auth: typing.Optional[str] = None):
     )
     matches = pattern.findall(str(readme.decoded_content))
     logger.info("Updating NIST plugins.")
-    for match in alive_it(matches, title="NIST Manifests"):
+    for match in tqdm(matches, desc="NIST Manifests"):
         url_parts = match[0].split("/")[3:]
         plugin_repo = gh.get_repo("/".join(url_parts[:2]))
         manifest = json.loads(
@@ -934,7 +934,7 @@ class registry:
         else:
             r = requests.post(url, headers=headers, data=data)
         valid, invalid = 0, {}
-        for r in alive_it(r.json()["results"], title="Updating Plugins from WIPP"):
+        for r in tqdm(r.json()["results"], desc="Updating Plugins from WIPP"):
             try:
                 manifest = registry._parse_xml(r["xml_content"])
                 plugin = submit_plugin(manifest)

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -546,7 +546,7 @@ class Plugin(WIPPPluginManifest):
     def __setattr__(self, name, value):
         if name != "_io_keys" and hasattr(self, "_io_keys"):
             if name in self._io_keys:
-                logger.info(
+                logger.debug(
                     "Value of %s in %s set to %s"
                     % (name, self.__class__.__name__, value)
                 )

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -762,12 +762,14 @@ def _error_log(val_err, manifest, fct):
             )
 
 
-def update_polus_plugins(gh_auth: typing.Optional[str] = None):
+def update_polus_plugins(
+    gh_auth: typing.Optional[str] = None, min_depth: int = 2, max_depth: int = 3
+):
 
     logger.info("Updating polus plugins.")
     # Get all manifests
     valid, invalid = scrape_manifests(
-        "polusai/polus-plugins", init_github(gh_auth), 1, 2, True
+        "polusai/polus-plugins", init_github(gh_auth), min_depth, max_depth, True
     )
     manifests = valid.copy()
     manifests.extend(invalid)

--- a/polus/plugins.py
+++ b/polus/plugins.py
@@ -443,7 +443,7 @@ class Plugin(WIPPPluginManifest):
         return self.containerId.split("/")[0]
 
     @property
-    def config_file(self):
+    def _config_file(self):
         inp = {x.name: str(x.value) for x in self.inputs}
         out = {x.name: str(x.value) for x in self.outputs}
         config = {"inputs": inp, "outputs": out}
@@ -456,7 +456,7 @@ class Plugin(WIPPPluginManifest):
 
     def save_config(self, path: typing.Union[str, pathlib.Path]):
         with open(path, "w") as fw:
-            json.dump(self.config_file, fw)
+            json.dump(self._config_file, fw)
         logger.debug("Saved config to %s" % (path))
 
     def load_config(self, path: typing.Union[str, pathlib.Path]):
@@ -465,13 +465,17 @@ class Plugin(WIPPPluginManifest):
         inp = config["inputs"]
         out = config["outputs"]
         for k, v in inp.items():
-            setattr(self, k, v)
+            if k in self._io_keys:
+                setattr(self, k, v)
         for k, v in out.items():
-            setattr(self, k, v)
+            if k in self._io_keys:
+                setattr(self, k, v)
         logger.debug("Loaded config from %s" % (path))
 
     def run(
-        self, gpus: Union[None, str, int] = "all", **kwargs,
+        self,
+        gpus: Union[None, str, int] = "all",
+        **kwargs,
     ):
 
         inp_dirs = []
@@ -620,7 +624,8 @@ def is_valid_manifest(plugin: dict) -> bool:
 
 
 def submit_plugin(
-    manifest: typing.Union[str, dict, pathlib.Path], refresh: bool = False,
+    manifest: typing.Union[str, dict, pathlib.Path],
+    refresh: bool = False,
 ) -> Plugin:
     """Parses a plugin and returns a Plugin object.
 
@@ -907,7 +912,8 @@ class Registry:
         self.password = password
 
     def get_current_schema(
-        self, verify: bool = True,
+        self,
+        verify: bool = True,
     ):
         """Return current schema in WIPP"""
         response = requests.get(
@@ -923,7 +929,10 @@ class Registry:
             response.raise_for_status()
 
     def upload_data(
-        self, filepath, schema_id, verify: bool = True,
+        self,
+        filepath,
+        schema_id,
+        verify: bool = True,
     ):
         """Upload data to registry"""
         with open(filepath, "r") as file_reader:
@@ -953,7 +962,9 @@ class Registry:
         return response.json()
 
     def publish_data(
-        self, data, verify: bool = True,
+        self,
+        data,
+        verify: bool = True,
     ):
         """Publish to public workspace"""
         data_publish_id = data["id"] + "/publish/"
@@ -977,7 +988,10 @@ class Registry:
         return response.json()
 
     def patch_resource(
-        self, pid, version, verify: bool = True,
+        self,
+        pid,
+        version,
+        verify: bool = True,
     ):
         """Patch resource."""
         # Get current version of the resource

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 python_on_whales>=0.34.0
 pygithub==1.55
-alive-progress>=2.1.0
 xmltodict>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python_on_whales>=0.34.0
 pygithub==1.55
 alive-progress>=2.1.0
+xmltodict>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "docker>=5.0.3",
         "pydantic>=1.8.2",
         "python_on_whales>=0.34.0",
-        "alive-progress>=2.1.0",
         "xmltodict>=0.12.0",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
         "pydantic>=1.8.2",
         "python_on_whales>=0.34.0",
         "alive-progress>=2.1.0",
+        "xmltodict>=0.12.0",
     ],
 )


### PR DESCRIPTION
*To be merged after #315*

All progress bars in `polus-plugins` are currently created using [alive-progress](https://github.com/rsalmei/alive-progress).
However, another progress bars library, [tqdm](https://tqdm.github.io/), is part of the requirements of `python-on-whales` which is **already** a requirement of `polus-plugins`.

Therefore, using `tqdm` instead of `alive-progress` would reduce the need for listing an extra requirement (no more `alive-progress`).

This PR switches all code that was using `alive-progress` to use `tqdm` and removes the requirements for `alive-progress`.