### PR TITLE
chore: region-segmentation-comparison CLT, json manifest fix

### DIFF
--- a/features/region-segmentation-comparison-plugin/plugin.cwl
+++ b/features/region-segmentation-comparison-plugin/plugin.cwl
@@ -1,0 +1,64 @@
+class: CommandLineTool
+cwlVersion: v1.2
+inputs:
+  fileExtension:
+    inputBinding:
+      prefix: --fileExtension
+    type: string
+  filePattern:
+    inputBinding:
+      prefix: --filePattern
+    type: string?
+  gtDir:
+    inputBinding:
+      prefix: --gtDir
+    type: Directory
+  individualData:
+    inputBinding:
+      prefix: --individualData
+    type: boolean?
+  individualSummary:
+    inputBinding:
+      prefix: --individualSummary
+    type: boolean?
+  inputClasses:
+    inputBinding:
+      prefix: --inputClasses
+    type: double
+  iouScore:
+    inputBinding:
+      prefix: --iouScore
+    type: string?
+  outDir:
+    inputBinding:
+      prefix: --outDir
+    type: Directory
+  predDir:
+    inputBinding:
+      prefix: --predDir
+    type: Directory
+  radiusFactor:
+    inputBinding:
+      prefix: --radiusFactor
+    type: string?
+  totalStats:
+    inputBinding:
+      prefix: --totalStats
+    type: boolean?
+  totalSummary:
+    inputBinding:
+      prefix: --totalSummary
+    type: boolean?
+outputs:
+  outDir:
+    outputBinding:
+      glob: $(inputs.outDir.basename)
+    type: Directory
+requirements:
+  DockerRequirement:
+    dockerPull: polusai/region-segmentation-comparison-plugin:0.2.2
+  InitialWorkDirRequirement:
+    listing:
+    - entry: $(inputs.outDir)
+      writable: true
+  InlineJavascriptRequirement: {}

--- a/features/region-segmentation-comparison-plugin/plugin.json
+++ b/features/region-segmentation-comparison-plugin/plugin.json
@@ -73,14 +73,12 @@
       "name": "filePattern",
       "type": "string",
       "description": "Filename pattern to filter data.",
-      "required": false,
-      "default": ".+"
+      "required": false
     },
     {
       "name": "fileExtension",
       "type": "enum",
       "description": "Output file format",
-      "default": "default",
       "options": {
         "values": [
           ".arrow",


### PR DESCRIPTION
This PR adds a CWL Command Line Tool (CLT) based on the plugin manifest for region-segmentation-comparison-plugin