### PR TITLE
chore: pixel-segmentation-comparison CLT, json manifest fix

### DIFF
--- a/features/pixel-segmentation-comparison-plugin/plugin.cwl
+++ b/features/pixel-segmentation-comparison-plugin/plugin.cwl
@@ -1,0 +1,48 @@
+class: CommandLineTool
+cwlVersion: v1.2
+inputs:
+  GTDir:
+    inputBinding:
+      prefix: --GTDir
+    type: Directory
+  PredDir:
+    inputBinding:
+      prefix: --PredDir
+    type: Directory
+  fileExtension:
+    inputBinding:
+      prefix: --fileExtension
+    type: string
+  filePattern:
+    inputBinding:
+      prefix: --filePattern
+    type: string?
+  individualStats:
+    inputBinding:
+      prefix: --individualStats
+    type: boolean?
+  inputClasses:
+    inputBinding:
+      prefix: --inputClasses
+    type: double
+  outDir:
+    inputBinding:
+      prefix: --outDir
+    type: Directory
+  totalStats:
+    inputBinding:
+      prefix: --totalStats
+    type: boolean?
+outputs:
+  outDir:
+    outputBinding:
+      glob: $(inputs.outDir.basename)
+    type: Directory
+requirements:
+  DockerRequirement:
+    dockerPull: polusai/pixel-segmentation-comparison-plugin:0.1.9
+  InitialWorkDirRequirement:
+    listing:
+    - entry: $(inputs.outDir)
+      writable: true
+  InlineJavascriptRequirement: {}

--- a/features/pixel-segmentation-comparison-plugin/plugin.json
+++ b/features/pixel-segmentation-comparison-plugin/plugin.json
@@ -37,8 +37,7 @@
       "name": "filePattern",
       "type": "string",
       "description": "Filename pattern to filter data.",
-      "required": false,
-      "default": ".+"
+      "required": false
     },
     {
       "name": "individualStats",
@@ -56,7 +55,6 @@
       "name": "fileExtension",
       "type": "enum",
       "description": "Output file format",
-      "default": "default",
       "options": {
         "values": [
           ".arrow",


### PR DESCRIPTION
This PR adds a CWL Command Line Tool (CLT) based on the plugin manifest for pixel-segmentation-comparison-plugin