### PR TITLE
style: removed 'Plugin' from name in pixel-segmentation-comparison

### DIFF
--- a/features/pixel-segmentation-comparison-plugin/plugin.json
+++ b/features/pixel-segmentation-comparison-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "Pixel Segmentation Comparison Plugin",
+  "name": "Pixel Segmentation Comparison",
   "version": "0.1.9",
   "title": "Pixel Segmentation Comparison Plugin",
   "description": "Plugin to generate evaluation metrics for pixel-wise comparison of ground truth and predicted images.",


### PR DESCRIPTION
This PR removes the last word "Plugin" from the value of `name` in `pixel-segmentation-comparison-plugin` manifest. This prevents this behavior:
```python3
import polus.plugins as pp
ps_comp = pp.PixelSegmentationComparisonPlugin # redundant
```
And instead users will be able to do this:
```python3
import polus.plugins as pp
ps_comp = pp.PixelSegmentationComparison
```