### PR TITLE
Updated github actions

### DIFF
--- a/.github/workflows/package-filter.yml
+++ b/.github/workflows/package-filter.yml
@@ -17,6 +17,8 @@ jobs:
     outputs:
       package_dirs: ${{ steps.package-filter.outputs.package_dirs }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Find Updated Package
         id: package-filter
         run: |

--- a/.github/workflows/package-filter.yml
+++ b/.github/workflows/package-filter.yml
@@ -3,45 +3,54 @@ name: Package Filter
 on:
   workflow_call:
     outputs:
-      package_dir:
-        description: "The directory containing the updated package"
-        value: ${{ jobs.package-filter.outputs.package_dir }}
-      package_name:
-        description: "The name of the updated package"
-        value: ${{ jobs.package-filter.outputs.package_name }}
+      package_dirs:
+        description: "The directories containing the updated packages"
+        value: ${{ jobs.package-filter.outputs.package_dirs }}
 
 permissions:
   contents: read
 
 jobs:
   package-filter:
-    name: Filter for updated package
+    name: Filter for updated packages
     runs-on: ubuntu-latest
     outputs:
-      package_dir: ${{ steps.package-filter.outputs.package_dir }}
-      package_name: ${{ steps.package-filter.outputs.package_name }}
+      package_dirs: ${{ steps.package-filter.outputs.package_dirs }}
     steps:
-      - name: Get changed files
-        uses: jitterbit/get-changed-files@v1
-        id: files-changed
-        with:
-          format: space-delimited
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Find Updated Package
         id: package-filter
         run: |
-          FOUND_PACKAGE=false
-          for changed_file in ${{ steps.files-changed.outputs.added }} ${{ steps.files-changed.outputs.modified }} ${{ steps.files-changed.outputs.renamed }}
+          CUR_DIR=$(pwd)
+          PACKAGE_DIRS=""
+
+          for changed_file in $(git diff --name-only ${{ github.base_ref }}...${{ github.head_ref }})
           do
+            # Check if the changed file is a pyproject.toml file
             if [[ "$(basename ${changed_file})" == *"pyproject.toml"* ]]
             then
-              echo "package_dir=$(dirname ${changed_file})" >> "$GITHUB_OUTPUT"
-              echo "package_name=$(basename $(dirname ${changed_file}))" >> "$GITHUB_OUTPUT"
-              FOUND_PACKAGE=true
-              break
+
+              # Check that the package has a VERSION file
+              if [[ ! -f "$(dirname ${changed_file})/VERSION" ]]
+              then
+                echo "::error::$(dirname ${changed_file}) does not have a VERSION file" && exit 1
+              fi
+
+              # Check that the version is a dev version
+              if [[ "$(cat $(dirname ${changed_file})/VERSION)" != *"dev"* ]]
+              then
+                echo "::error::$(dirname ${changed_file}) does not have a dev version" && exit 1
+              fi
+
+              PACKAGE_DIRS="$PACKAGE_DIRS $(dirname ${changed_file})"
             fi
           done
-          if [[ "$FOUND_PACKAGE" = false ]]
+
+          cd "$CUR_DIR"
+
+          # Check if any packages were found
+          if [[ -z "$PACKAGE_DIRS" ]]
           then
-            echo "::error::No pyproject.toml file found among changed files" && exit 1
+            echo "::error::No updated packages were found" && exit 1
           fi
+
+          echo "package_dirs=$(PACKAGE_DIRS)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/package-filter.yml
+++ b/.github/workflows/package-filter.yml
@@ -19,13 +19,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Find Updated Package
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+      - name: Find Updated Packages
         id: package-filter
         run: |
           CUR_DIR=$(pwd)
           PACKAGE_DIRS=""
 
-          for changed_file in $(git diff --name-only ${{ github.base_ref }}...${{ github.head_ref }})
+          for changed_file in $(git diff --name-only origin/${{ github.base_ref }}...)
           do
             # Check if the changed file is a pyproject.toml file
             if [[ "$(basename ${changed_file})" == *"pyproject.toml"* ]]
@@ -55,4 +58,4 @@ jobs:
             echo "::error::No updated packages were found" && exit 1
           fi
 
-          echo "package_dirs=$(PACKAGE_DIRS)" >> "$GITHUB_OUTPUT"
+          echo "package_dirs=${PACKAGE_DIRS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -22,7 +22,7 @@ jobs:
     needs: package-filter
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -17,6 +17,7 @@ jobs:
 
   package-release:
     name: Bump release version of updated package
+    if: github.repository == 'polusai/polus-plugins'
     runs-on: ubuntu-latest
     needs: package-filter
     steps:
@@ -30,27 +31,28 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install bump2version
-      - name: Get Old Version
-        id: old_version
+      - name: Bump Version on all updated packages
         run: |
-          cd "${{ needs.package-filter.outputs.package_dir }}"
-          if [[ "$(cat VERSION)" != *"dev"* ]]
-          then
-            echo "::error::${{ needs.package-filter.outputs.package_name }} does not have a dev version" && exit 1
-          fi
-          echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
-      - name: Bump Version
-        id: bump_version
-        run: |
-          cd "${{ needs.package-filter.outputs.package_dir }}"
-          bump2version release --no-commit
-          echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+          CUR_DIR=$(pwd)
+
+          for package_dir in ${{ needs.package-filter.outputs.package_dirs }}
+          do
+            cd "$CUR_DIR/$package_dir"
+            bump2version release --no-commit
+          done
+
+          cd "$CUR_DIR"
       - name: Commit and push all changed files
         env:
-          CI_COMMIT_MESSAGE: Bumped version for "${{ needs.package-filter.outputs.package_name }}" from ${{ steps.old_version.outputs.version }} to ${{ steps.bump_version.outputs.version }}
           CI_COMMIT_AUTHOR: Continuous Integration
         run: |
+          PKG_NAMES=""
+          for package_dir in ${{ needs.package-filter.outputs.package_dirs }}
+          do
+            PKG_NAMES="$PKG_NAMES $(basename $package_dir)"
+          done
+
           git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
           git config --global user.email "username@users.noreply.github.com"
-          git commit -a -m "build: ${{ env.CI_COMMIT_MESSAGE }}"
+          git commit -a -m "build: Bumped release version for $PKG_NAMES"
           git push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,8 @@ jobs:
             then
               echo "::error::pre-commit hooks failed for $(basename ${package_dir})" && exit 1
             fi
+            cd $CUR_DIR
           done
-
-          cd $CUR_DIR
       - name: Run tests
         run: |
           CUR_DIR=$(pwd)
@@ -60,6 +59,5 @@ jobs:
             cd $package_dir
             poetry update && poetry install
             poetry run pytest -v
+            cd $CUR_DIR
           done
-
-          cd $CUR_DIR

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,9 @@ on:
       - dev
   workflow_call:
     outputs:
-      package_dir:
-        description: "The directory containing the updated package"
-        value: ${{ jobs.package-filter.outputs.package_dir }}
-      package_name:
-        description: "The name of the updated package"
-        value: ${{ jobs.package-filter.outputs.package_name }}
+      package_dirs:
+        description: "The directories containing the updated packages"
+        value: ${{ jobs.package-filter.outputs.package_dirs }}
 
 permissions:
   contents: read
@@ -36,19 +33,33 @@ jobs:
           python-version: '3.9'
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2
-      - name: Install package
+      - name: Install pre-commit
         run: |
-          cd ${{ needs.package-filter.outputs.package_dir }}
-          poetry install --no-interaction
-      - name: Run pre-commit hooks
+          pip install pre-commit
+      - name: Run pre-commit hooks and check for changes
         run: |
-          cd ${{ needs.package-filter.outputs.package_dir }}
-          poetry run pre-commit run --files ./**/**
-          if [[ $(git status --porcelain) ]]
-          then
-            echo "::error::pre-commit hooks failed" && exit 1
-          fi
+          CUR_DIR=$(pwd)
+
+          for package_dir in ${{ needs.package-filter.outputs.package_dirs }}
+          do
+            cd $package_dir
+            poetry run pre-commit run --files ./**/**
+            if [[ $(git status --porcelain) ]]
+            then
+              echo "::error::pre-commit hooks failed for $(basename ${package_dir})" && exit 1
+            fi
+          done
+
+          cd $CUR_DIR
       - name: Run tests
         run: |
-          cd ${{ needs.package-filter.outputs.package_dir }}
-          poetry run pytest -v
+          CUR_DIR=$(pwd)
+
+          for package_dir in ${{ needs.package-filter.outputs.package_dirs }}
+          do
+            cd $package_dir
+            poetry update && poetry install
+            poetry run pytest -v
+          done
+
+          cd $CUR_DIR

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     needs: package-filter
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This PR:

- updates the `package-filter` action to:
  - succeed even when the source branch is not up-to-date with the target branch
  - find all updated packages and outputs their directories
  - test if there is always a `VERSION` file to accompany an updated `pyproject.toml` file
  - test that every updated package has a `dev` version
  - test that at least one package was updated
- updates the `tests` action to run pre-commit hooks and pytest on _all_ updated packages
- updates the `package-release` action to:
  - bump the release version for all updated packages
  - make a single commit for bumping version in all those packages