### PR TITLE
bugfix(ci): fix bug in GitHub Actions pre-commit workflow

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -41,9 +41,7 @@ jobs:
         run: |
           cd "${{ matrix.package_dir }}"
           uv sync --all-extras
-          uv run pre-commit run \
-            --from-ref ${{ github.event.pull_request.base.sha || github.event.before }} \
-            --to-ref ${{ github.event.pull_request.head.sha || github.sha }}
+          uv run pre-commit run --files ./**/**
 
       - name: Show dirty files (if pre-commit failed)
         if: failure()


### PR DESCRIPTION
This PR fixes a bug where pre-commit was run with --from-ref/--to-ref, which can fail when SHA refs are unavailable on fork branches without an open PR.