### PR TITLE
bugfix(ci): fix a bug in the package release workflow

### DIFF
--- a/formats/file-renaming-tool/.bumpversion.cfg
+++ b/formats/file-renaming-tool/.bumpversion.cfg
@@ -22,7 +22,7 @@ replace = version = "{new_version}"
 
 [bumpversion:file:plugin.json]
 
-[bumpversion:file:FileRenaming.cwl]
+[bumpversion:file:filerenaming.cwl]
 
 [bumpversion:file:ict.yaml]
 


### PR DESCRIPTION
## Summary
Fixes the **Package Release** workflow failing when `bump2version release` runs for `formats/file-renaming-tool`.

## Problem
`.bumpversion.cfg` referenced `FileRenaming.cwl`, but the repository file is `filerenaming.cwl`. On Linux (GitHub Actions), the filesystem is case-sensitive, so bump2version raised `FileNotFoundError` and the job exited with an error.

## Change
- Update `[bumpversion:file:...]` in `formats/file-renaming-tool/.bumpversion.cfg` to use `filerenaming.cwl`.
