### PR TITLE
bugfix(ci): allow Package Release workflow to succeed with no pre-rel…

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -37,6 +37,7 @@ jobs:
   package-release:
     name: Release Versions
     needs: pre-release-filter
+    if: ${{ needs.pre-release-filter.outputs.list != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Debug | Repository Name
@@ -118,6 +119,7 @@ jobs:
   docker:
     name: Docker | ${{ matrix.package_name }}
     needs: [pre-release-filter, package-release]
+    if: ${{ needs.pre-release-filter.outputs.list != '' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.pre-release-filter.outputs.matrix) }}

--- a/.github/workflows/pre-release-filter.yml
+++ b/.github/workflows/pre-release-filter.yml
@@ -95,11 +95,14 @@ jobs:
           PACKAGE_DIRS=$(echo $PACKAGE_DIRS | xargs)
           INCOMPLETE_DIRS=$(echo $INCOMPLETE_DIRS | xargs)
 
-          # Check if any packages were found
           echo "The updated packages are $PACKAGE_DIRS"
           if [ -z "$PACKAGE_DIRS" ]
           then
-            echo "::error::No updated packages were found" && exit 1
+            echo "::warning::No pre-release packages found (no complete package has dev in VERSION). Nothing to release."
+            echo 'matrix={"include":[]}' >> $GITHUB_OUTPUT
+            echo "list=" >> $GITHUB_OUTPUT
+            echo "incomplete=$( echo "$INCOMPLETE_DIRS" )" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           # Convert the package directories to JSON for the output matrix


### PR DESCRIPTION
Problem
Package Release runs the pre-release filter first. When every qualifying package had already been released (no dev in VERSION), the filter step failed with “No updated packages were found” and the whole workflow went red even though there was legitimately nothing to release.

Changes

pre-release-filter.yml: If no packages match, log a warning (not an error), write empty matrix / list outputs, and exit successfully.
package-release.yml: Run Release Versions and Docker only when pre-release-filter.outputs.list is non-empty, so bump/Docker steps are not invoked for an empty set.
Result
Manual or scheduled Package Release runs pass when there is nothing to promote; runs that do have dev versions behave as before.