### PR TITLE
fix: parallel input reads without deadlock

### DIFF
--- a/regression/basic-flatfield-estimation-tool/pyproject.toml
+++ b/regression/basic-flatfield-estimation-tool/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numpy>=2.0.0",
     "tqdm==4.67.3",
     "basicpy @ git+https://github.com/ndonyapour/BaSiCPy.git@chore/update-supported-python",
+    "jgo==1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/regression/basic-flatfield-estimation-tool/src/polus/images/regression/basic_flatfield_estimation/utils.py
+++ b/regression/basic-flatfield-estimation-tool/src/polus/images/regression/basic_flatfield_estimation/utils.py
@@ -47,8 +47,13 @@ def get_image_stack(image_paths: list[pathlib.Path]) -> numpy.ndarray:
         random.shuffle(image_paths)
         image_paths = image_paths[:n]
 
-    images = []
-    with concurrent.futures.ProcessPoolExecutor(max_workers=5) as executor:
+    ctx = multiprocessing.get_context("spawn")
+    images: list[tuple[int, numpy.ndarray]] = []
+
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=5,
+        mp_context=ctx,
+    ) as executor:
         futures = []
         for i, path in enumerate(image_paths):
             futures.append(executor.submit(_load_img, path, i))


### PR DESCRIPTION
The process pool was using fork, so the workers inherited a parent process that already had the Bio-Formats JVM loaded, which caused the deadlock. Currently it uses` multiprocessing.get_context("spawn")` so workers are not forked from a parent that may already have the JVM loaded.

Dependencies: Pin jgo==1.1.0 (downgrade from 2.2.x)  to avoid failures seen when multiple processes hit jgo / Java bootstrap concurrently. 